### PR TITLE
feat: add page timeout mechanism

### DIFF
--- a/site.config.js
+++ b/site.config.js
@@ -171,6 +171,7 @@ module.exports = {
       page: '/maintain',
     },
   },
+  pageProcessTimeout: 3500,
   reduxCookiePersist: {
     enabled: false,
     stateSubTrees: [],

--- a/src/pages/[pageName]/[pageSlug].tsx
+++ b/src/pages/[pageName]/[pageSlug].tsx
@@ -15,7 +15,7 @@ import {
 } from 'react-notion-x'
 
 import { logOption } from '../../../types'
-import { notion } from '../../../site.config'
+import { notion, pageProcessTimeout } from '../../../site.config'
 import { PAGE_TYPE_ARTICLE_SINGLE_PAGE } from '../../libs/constant'
 import {
   extractSinglePagePath,
@@ -32,6 +32,7 @@ import {
   fetchArticleStream,
   isValidPageSlug,
   isValidPageName,
+  executeFunctionWithTimeout,
 } from '../../libs/server/page'
 import {
   transformArticleStream,
@@ -49,72 +50,95 @@ import NotionPageFooter from '../../components/notion-page-footer'
 
 export const getServerSideProps: GetServerSideProps = wrapper.getServerSideProps(
   store => async ({ params: { pageName, pageSlug }, req, res }) => {
-    if (!isValidPageName(pageName) || !isValidPageSlug(pageSlug)) {
-      const options: logOption = {
-        category: PAGE_TYPE_ARTICLE_SINGLE_PAGE,
-        message: `invalid page | pageName: ${pageName} | pageSlug: ${pageSlug}`,
-        level: 'error',
-        req,
-      }
-      log(options)
-      return showCommonPage(req, res, 'notFound', pageName)
-    }
+    const props = await executeFunctionWithTimeout(
+      async () => {
+        if (!isValidPageName(pageName) || !isValidPageSlug(pageSlug)) {
+          const options: logOption = {
+            category: PAGE_TYPE_ARTICLE_SINGLE_PAGE,
+            message: `invalid page | pageName: ${pageName} | pageSlug: ${pageSlug}`,
+            level: 'error',
+            req,
+          }
+          log(options)
+          return showCommonPage(req, res, 'notFound', pageName)
+        }
 
-    const { pageId: articleId } = extractSinglePagePath(pageSlug)
+        const { pageId: articleId } = extractSinglePagePath(pageSlug)
 
-    try {
-      let articleStream = {}
-      const response = await fetchArticleStream({
-        req,
-        pageName,
-        category: PAGE_TYPE_ARTICLE_SINGLE_PAGE,
-      })
-      articleStream = await transformArticleStream(pageName, response)
-      articleStream = await transformArticleStreamPreviewImages(articleStream)
+        try {
+          let articleStream = {}
+          const response = await fetchArticleStream({
+            req,
+            pageName,
+            category: PAGE_TYPE_ARTICLE_SINGLE_PAGE,
+          })
+          articleStream = await transformArticleStream(pageName, response)
+          articleStream = await transformArticleStreamPreviewImages(
+            articleStream
+          )
 
-      // since getPage for collection view returns all pages with partial blocks, getPage target article then merge to articleStream to add missing blocks
-      const singleArticleResponse = await fetchArticleStream({
-        req,
-        pageId: articleId,
-        category: PAGE_TYPE_ARTICLE_SINGLE_PAGE,
-      })
-      let singleArticle = await transformSingleArticle(singleArticleResponse)
-      singleArticle = await transformArticleStreamPreviewImages(singleArticle)
-      articleStream = merge(articleStream, singleArticle)
+          // since getPage for collection view returns all pages with partial blocks, getPage target article then merge to articleStream to add missing blocks
+          const singleArticleResponse = await fetchArticleStream({
+            req,
+            pageId: articleId,
+            category: PAGE_TYPE_ARTICLE_SINGLE_PAGE,
+          })
+          let singleArticle = await transformSingleArticle(
+            singleArticleResponse
+          )
+          singleArticle = await transformArticleStreamPreviewImages(
+            singleArticle
+          )
+          articleStream = merge(articleStream, singleArticle)
 
-      const menuItems = transformMenuItems(pageName, articleStream)
-      const toc = transformTableOfContent(articleStream, articleId)
+          const menuItems = transformMenuItems(pageName, articleStream)
+          const toc = transformTableOfContent(articleStream, articleId)
 
-      // save SSR fetch stream article contents to redux store
-      const payload = transformStreamActionPayload(pageName, articleStream)
-      const action = updateStream(payload)
-      store.dispatch(action)
+          // save SSR fetch stream article contents to redux store
+          const payload = transformStreamActionPayload(pageName, articleStream)
+          const action = updateStream(payload)
+          store.dispatch(action)
 
-      const options: logOption = {
-        category: 'page',
-        message: `dumpaccess to /${pageName}/${pageSlug}`,
-        level: 'info',
-        req,
-      }
-      log(options)
-      return {
-        props: {
-          menuItems,
-          pageId: idToUuid(articleId),
-          pageName,
-          toc,
-        },
-      }
-    } catch (err) {
-      const options: logOption = {
-        category: PAGE_TYPE_ARTICLE_SINGLE_PAGE,
-        message: err,
-        level: 'error',
-        req,
-      }
-      log(options)
-      return showCommonPage(req, res, 'error', pageName)
-    }
+          const options: logOption = {
+            category: 'page',
+            message: `dumpaccess to /${pageName}/${pageSlug}`,
+            level: 'info',
+            req,
+          }
+          log(options)
+          return {
+            props: {
+              menuItems,
+              pageId: idToUuid(articleId),
+              pageName,
+              toc,
+            },
+          }
+        } catch (err) {
+          const options: logOption = {
+            category: PAGE_TYPE_ARTICLE_SINGLE_PAGE,
+            message: err,
+            level: 'error',
+            req,
+          }
+          log(options)
+          return showCommonPage(req, res, 'error', pageName)
+        }
+      },
+      pageProcessTimeout,
+      duration => {
+        const options: logOption = {
+          category: PAGE_TYPE_ARTICLE_SINGLE_PAGE,
+          message: `page processing timeout | duration: ${duration} ms`,
+          level: 'warn',
+          req,
+        }
+        log(options)
+        return showCommonPage(req, res, 'error', pageName)
+      },
+      PAGE_TYPE_ARTICLE_SINGLE_PAGE
+    )
+    return props
   }
 )
 


### PR DESCRIPTION
## Goal

Add page timeout mechanism to prevent Vercel lambda 504 timeout for page rendering.

## Knowledge Transfer

### Vercel Serverless Lambda Limit

`timeout: 5s`

https://vercel.com/docs/concepts/limits/overview#general-limits

### timeout mechanism reference

- https://github.com/sindresorhus/p-timeout
- https://github.com/sindresorhus/promise-fun (all available promise utilities)

### cancel promise / async function

- https://leanylabs.com/blog/cancel-promise-abortcontroller/
- https://medium.com/@bramus/cancel-a-javascript-promise-with-abortcontroller-3540cbbda0a9
- https://github.com/tc39/proposal-cancelable-promises (TC39 proposal was withdrawn)
- https://nodejs.org/docs/latest-v14.x/api/globals.html#globals_class_abortcontroller
- [如何取消你的 Promise？](https://juejin.cn/post/6844903533393772557)
- The stream, child_process, and fs module support AbortController now. ([Reference](https://github.com/sindresorhus/p-cancelable/issues/27))
- https://developer.mozilla.org/en-US/docs/Web/API/AbortController

### pass Node.js flag via NODE_OPTIONS

```
NODE_OPTIONS=--experimental-abortcontroller
```

https://nodejs.org/docs/latest-v14.x/api/cli.html#cli_node_options_options


### function execution timing

https://developer.mozilla.org/en-US/docs/Web/API/Performance/now