### PR TITLE
Release 4.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [4.12.1](https://github.com/dazedbear/dazedbear.github.io/compare/v4.12.0...v4.12.1) (2022-04-04)
+
+### Bug Fixes
+
+- incorrect size of article content cover ([ed02a9d](https://github.com/dazedbear/dazedbear.github.io/commit/ed02a9db7c76023736999dea7b0b3db1b61940cf))
+
 ## [4.12.0](https://github.com/dazedbear/dazedbear.github.io/compare/v4.11.4...v4.12.0) (2022-04-04)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dazedbear.github.io",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "scripts": {
     "dev": "next dev",
     "start": "next start",

--- a/src/styles/notion.css
+++ b/src/styles/notion.css
@@ -36,7 +36,10 @@
     @apply -top-40 lg:-top-16;
   }
   #app .notion-page-cover {
-    @apply max-h-unset min-h-unset h-auto object-center object-contain;
+    @apply object-center object-contain;
+    height: auto !important;
+    min-height: unset !important;
+    max-height: unset !important;
   }
   #app .notion-page-link {
     @apply h-auto;


### PR DESCRIPTION
<!--
This template is for release PR. Please copy and paste new content generated by `npm run release` from CHANGELOG.md.

## [4.5.0](https://github.com/dazedbear/dazedbear.github.io/compare/v4.4.2...v4.5.0) (2021-10-06)

### Features

- add new feature ([224fad3](https://github.com/dazedbear/dazedbear.github.io/commit/224fad38b2898fde8837e9069d0deb096e321591))
-->

### [4.12.1](https://github.com/dazedbear/dazedbear.github.io/compare/v4.12.0...v4.12.1) (2022-04-04)

### Bug Fixes

- incorrect size of article content cover ([ed02a9d](https://github.com/dazedbear/dazedbear.github.io/commit/ed02a9db7c76023736999dea7b0b3db1b61940cf))

<img width="1680" alt="截圖 2022-04-05 上午12 57 29" src="https://user-images.githubusercontent.com/8896191/161594268-f6ce3fdc-9aa9-49d7-b849-bcdcdbed41ea.png">