### PR TITLE
Release 4.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [4.12.2](https://github.com/dazedbear/dazedbear.github.io/compare/v4.12.1...v4.12.2) (2022-04-05)
+
+### Performance
+
+- add cache headers to API routes ([368bef9](https://github.com/dazedbear/dazedbear.github.io/commit/368bef974b6d82b5be8963ec2198b8518f2b7a71))
+- add cache headers to ssr pages ([f0122db](https://github.com/dazedbear/dazedbear.github.io/commit/f0122db2fc35605cefee379ca0013efd80a31733))
+
 ### [4.12.1](https://github.com/dazedbear/dazedbear.github.io/compare/v4.12.0...v4.12.1) (2022-04-04)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dazedbear.github.io",
-  "version": "4.12.1",
+  "version": "4.12.2",
   "scripts": {
     "dev": "next dev",
     "start": "next start",

--- a/src/libs/server/api.ts
+++ b/src/libs/server/api.ts
@@ -1,4 +1,4 @@
-import { NextApiRequest } from 'next'
+import { NextApiRequest, NextApiResponse } from 'next'
 import createError from 'http-errors'
 import Ajv from 'ajv'
 import addFormats from 'ajv-formats'
@@ -111,4 +111,24 @@ export const validateRequest = (
     })
     throw createError(400)
   }
+}
+
+/**
+ * set cache headers for API routes
+ * @param res {object} res
+ */
+export const setAPICacheHeaders = (res: NextApiResponse): void => {
+  /**
+   * < s-maxage: data is fresh, serve cache. X-Vercel-Cache HIT
+   * s-maxage - stale-while-revalidate: data is stale, still serve cache and start background new cache generation. X-Vercel-Cache STALE
+   * > stale-while-revalidate: data is stale and cache won't be used any more. X-Vercel-Cache MISS
+   *
+   * @see https://vercel.com/docs/concepts/edge-network/caching#serverless-functions---lambdas
+   * @see https://vercel.com/docs/concepts/edge-network/x-vercel-cache
+   * @see https://web.dev/stale-while-revalidate/
+   */
+  res.setHeader(
+    'Cache-Control',
+    'public, s-maxage=30, stale-while-revalidate=86400'
+  )
 }

--- a/src/libs/server/page.ts
+++ b/src/libs/server/page.ts
@@ -235,3 +235,23 @@ export const executeFunctionWithTimeout = async (
   }
   return result
 }
+
+/**
+ * set cache headers for the pages which use getServerSideProps
+ * @param res {object} res
+ */
+export const setSSRCacheHeaders = (res: GetServerSidePropsResponse): void => {
+  /**
+   * < s-maxage: data is fresh, serve cache. X-Vercel-Cache HIT
+   * s-maxage - stale-while-revalidate: data is stale, still serve cache and start background new cache generation. X-Vercel-Cache STALE
+   * > stale-while-revalidate: data is stale and cache won't be used any more. X-Vercel-Cache MISS
+   *
+   * @see https://vercel.com/docs/concepts/edge-network/caching#serverless-functions---lambdas
+   * @see https://vercel.com/docs/concepts/edge-network/x-vercel-cache
+   * @see https://web.dev/stale-while-revalidate/
+   */
+  res.setHeader(
+    'Cache-Control',
+    'public, s-maxage=30, stale-while-revalidate=86400'
+  )
+}

--- a/src/pages/[pageName]/[pageSlug].tsx
+++ b/src/pages/[pageName]/[pageSlug].tsx
@@ -55,6 +55,7 @@ import {
   isValidPageSlug,
   isValidPageName,
   executeFunctionWithTimeout,
+  setSSRCacheHeaders,
 } from '../../libs/server/page'
 import {
   transformArticleStream,
@@ -137,6 +138,7 @@ export const getServerSideProps: GetServerSideProps = wrapper.getServerSideProps
             req,
           }
           log(options)
+          setSSRCacheHeaders(res)
           return {
             props: {
               menuItems,

--- a/src/pages/[pageName]/index.tsx
+++ b/src/pages/[pageName]/index.tsx
@@ -27,6 +27,7 @@ import {
   fetchArticleStream,
   isValidPageName,
   executeFunctionWithTimeout,
+  setSSRCacheHeaders,
 } from '../../libs/server/page'
 import {
   transformArticleStream,
@@ -78,6 +79,7 @@ export const getServerSideProps: GetServerSideProps = wrapper.getServerSideProps
             req,
           }
           log(options)
+          setSSRCacheHeaders(res)
           return {
             props: {
               menuItems,

--- a/src/pages/api/posts.ts
+++ b/src/pages/api/posts.ts
@@ -7,7 +7,11 @@ import {
   getNotionPostsFromTable,
   getNotionPreviewImages,
 } from '../../libs/server/notion'
-import { getCategory, validateRequest } from '../../libs/server/api'
+import {
+  getCategory,
+  validateRequest,
+  setAPICacheHeaders,
+} from '../../libs/server/api'
 import { notion } from '../../../site.config'
 
 const route = '/posts'
@@ -122,7 +126,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       ['result', 'reducerResults', 'collection_group_results', 'hasNext'],
       currentIndex + 1 < currentTotal
     )
-
+    setAPICacheHeaders(res)
     res.status(200).json(data)
   } catch (err) {
     const statusCode = err.status || 500

--- a/src/pages/api/sitemap.ts
+++ b/src/pages/api/sitemap.ts
@@ -1,5 +1,9 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { getCategory, validateRequest } from '../../libs/server/api'
+import {
+  getCategory,
+  validateRequest,
+  setAPICacheHeaders,
+} from '../../libs/server/api'
 import get from 'lodash/get'
 import { SitemapStream, streamToPromise } from 'sitemap'
 import { Readable } from 'stream'
@@ -97,8 +101,9 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       generateSiteMapXml.bind(this, req),
       { ttl: cacheConfig.ttls.sitemap }
     )
-    res.writeHead(200, { 'Content-Type': 'application/xml' })
-    res.end(sitemapXml)
+    setAPICacheHeaders(res)
+    res.setHeader('Content-Type', 'application/xml')
+    res.status(200).end(sitemapXml)
   } catch (err) {
     const statusCode = err.status || 500
     res.status(statusCode).send(err.message)


### PR DESCRIPTION
<!--
This template is for release PR. Please copy and paste new content generated by `npm run release` from CHANGELOG.md.

## [4.5.0](https://github.com/dazedbear/dazedbear.github.io/compare/v4.4.2...v4.5.0) (2021-10-06)

### Features

- add new feature ([224fad3](https://github.com/dazedbear/dazedbear.github.io/commit/224fad38b2898fde8837e9069d0deb096e321591))
-->

### [4.12.2](https://github.com/dazedbear/dazedbear.github.io/compare/v4.12.1...v4.12.2) (2022-04-05)

### Performance

- add cache headers to API routes ([368bef9](https://github.com/dazedbear/dazedbear.github.io/commit/368bef974b6d82b5be8963ec2198b8518f2b7a71))

<img width="1538" alt="api-cache-header-before" src="https://user-images.githubusercontent.com/8896191/161704396-f8096537-ffe4-4fc0-80fd-9a55b99558f5.png">

- add cache headers to ssr pages ([f0122db](https://github.com/dazedbear/dazedbear.github.io/commit/f0122db2fc35605cefee379ca0013efd80a31733))

<img width="1555" alt="ssr-page-cache-header-before" src="https://user-images.githubusercontent.com/8896191/161704423-05da9638-75a3-463c-bf8b-3c41fa360db6.png">


### Reference

Next.js
- https://github.com/vercel/next.js/tree/canary/examples/ssr-caching
- [On-demand ISR since Next.js 12.1](https://nextjs.org/blog/next-12-1?utm_source=next-site&utm_medium=banner&utm_campaign=next-website#on-demand-incremental-static-regeneration-beta)
- [Custom headers - Cache control](https://nextjs.org/docs/api-reference/next.config.js/headers#cache-control)
- [Example: SSR Caching](https://github.com/vercel/next.js/tree/canary/examples/ssr-caching)

Vercel
- [Caching for lambdas](https://vercel.com/docs/concepts/edge-network/caching#serverless-functions---lambdas)
- [X-Vercel-Cache](https://vercel.com/docs/concepts/edge-network/x-vercel-cache)
- [Cache-Control header](https://vercel.com/docs/concepts/edge-network/headers#cache-control-header)
- [Example: add custom headers in edge function](https://github.com/vercel/examples/tree/main/edge-functions/add-header)

Google
- [Explanation to stale-while-validate](https://web.dev/stale-while-revalidate/)
![C8lg2FSEqhTKR6WmYky3](https://user-images.githubusercontent.com/8896191/161707122-2294240c-d11c-4fe0-a500-81b1359abd04.svg)

