### PR TITLE
ci: use vercel host name for stage failsafe generation

### DIFF
--- a/.github/workflows/failsafe.yml
+++ b/.github/workflows/failsafe.yml
@@ -1,7 +1,9 @@
 name: Failsafe Page Generation
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
+  pull_request:
+    branches: [main]
   schedule:
     # every day 06:00, 18:00 GMT+8
     - cron: '0 10,22 * * *'
@@ -21,7 +23,7 @@ jobs:
   failsafe-generation-stage:
     name: Failsafe Page Generation Stage
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/develop' }}
+    if: contains(github.ref, 'refs/pull')
     needs: wait-for-deployment
     env:
       NEXT_PUBLIC_APP_ENV: stage
@@ -40,7 +42,7 @@ jobs:
   failsafe-generation-production:
     name: Failsafe Page Generation Production
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: github.ref == 'refs/heads/main'
     needs: wait-for-deployment
     env:
       NEXT_PUBLIC_APP_ENV: production

--- a/.github/workflows/failsafe.yml
+++ b/.github/workflows/failsafe.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   wait-for-deployment:
-    uses: dazedbear/dazedbear.github.io/.github/workflows/vercel-deployment.yml@main
+    uses: ./.github/workflows/vercel-deployment.yml
     secrets:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
@@ -27,6 +27,7 @@ jobs:
     needs: wait-for-deployment
     env:
       NEXT_PUBLIC_APP_ENV: stage
+      VERCEL_URL: ${{ needs.wait-for-deployment.outputs.vercel-deployment-url }}
     steps:
       - name: Checkout project source
         uses: actions/checkout@v2

--- a/.github/workflows/vercel-deployment.yml
+++ b/.github/workflows/vercel-deployment.yml
@@ -2,6 +2,10 @@ name: Wait for Vercel Deployment
 
 on:
   workflow_call:
+    outputs:
+      vercel-deployment-url: 
+        description: "The vercel deployment url"
+        value: ${{ jobs.wait-for-vercel-deployment.outputs.vercel-deployment-url }}
     secrets:
       VERCEL_TOKEN:
         required: true
@@ -13,6 +17,8 @@ jobs:
   wait-for-vercel-deployment:
     name: Wait for current Vercel deployment to be ready
     runs-on: ubuntu-latest
+    outputs:
+      vercel-deployment-url: ${{ steps.expose-vercel-deployment.outputs.vercel-deployment-url }}
     steps:
       - name: Sleep to wait for new deployment is created
         run: sleep 10
@@ -36,6 +42,8 @@ jobs:
         with:
           deployment-url: ${{ env.VERCEL_DEPLOYMENT_URL }} # Must only contain the domain name (no http prefix, etc.)
           timeout: 240 # Wait for 4 mins before failing
-
+      - name: Expose Vercel deployment info
+        id: expose-vercel-deployment
+        run: echo "::set-output name=vercel-deployment-url::${{ env.VERCEL_DEPLOYMENT_URL }}"
       - name: Display Vercel deployment status
         run: 'echo The deployment at ${{ fromJson(steps.await-vercel.outputs.deploymentDetails).url }} is ${{ fromJson(steps.await-vercel.outputs.deploymentDetails).readyState }}'

--- a/site.config.js
+++ b/site.config.js
@@ -248,8 +248,14 @@ module.exports = {
       protocol: 'http',
     },
     stage: {
-      host: 'stage.dazedbear.pro',
-      hostname: 'stage.dazedbear.pro',
+      host: env
+        .get('VERCEL_URL')
+        .default('stage.dazedbear.pro')
+        .asString(),
+      hostname: env
+        .get('VERCEL_URL')
+        .default('stage.dazedbear.pro')
+        .asString(),
       protocol: 'https',
     },
     production: {


### PR DESCRIPTION
## Goal

<!-- Please describe what's the main purpose of this PR -->

- update failsafe generation for stage env to allow Vercel-generated host names.

## Knowledge Transfer / Notes

<!-- Anything worth sharing? E.g. when introducing new technologies, libraries, design patterns, techniques, best practices or any learnings while working on this change. -->

I changed the collaboration flow of this repository, so I no longer need `stage.dazedbear.pro` domain for preview. Thus, I have to update the failsafe generation for stage preview.

### Old collaboration flow

- push commits / open PR to `develop` branch for any code changes
- visit `stage.dazedbear.pro` which assigned to `develop` branch for preview
- create pull requests from `develop` to `main` branch and run `npm run release` manually for production release and release note generation

### New collaboration flow

- create pull requests from any branches other than `main` for any code changes
- visit the Vercel-generated hostname from the comment in PR for preview
- merge the PR to trigger automatic release note generation

## Reference

<!-- Anything reference can be placed here -->

- [github action expression `contains`](https://docs.github.com/en/actions/learn-github-actions/expressions#contains)
- [github action `jobs.<job_id>.if`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idif)
- [github action `jobs.<job_id>.uses`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_iduses)
- [github action `jobs.<job_id>.outputs`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idoutputs)
- [github action `on.workflow_call.outputs`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_calloutputs)
- [github action context](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context)
- [Vercel system environment variables](https://vercel.com/docs/concepts/projects/environment-variables#system-environment-variables)
- [Vercel preview branches](https://vercel.com/docs/concepts/git#preview-branches)