### PR TITLE
chore: fix release note generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
-## [4.15.1](https://github.com/dazedbear/dazedbear.github.io/compare/v4.15.0...v4.15.1) (2022-08-06)
-
-# [4.15.0](https://github.com/dazedbear/dazedbear.github.io/compare/v4.14.1...v4.15.0) (2022-08-06)
-
 # Changelog
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+## [4.15.1](https://github.com/dazedbear/dazedbear.github.io/compare/v4.15.0...v4.15.1) (2022-08-06)
+
+# [4.15.0](https://github.com/dazedbear/dazedbear.github.io/compare/v4.14.1...v4.15.0) (2022-08-06)
 
 ### [4.14.1](https://github.com/dazedbear/dazedbear.github.io/compare/v4.14.0...v4.14.1) (2022-05-21)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "@types/react": "^16.9.17",
         "@types/react-redux": "^7.1.21",
         "autoprefixer": "^10.4.7",
+        "conventional-changelog-conventionalcommits": "^5.0.0",
         "cz-conventional-changelog": "^3.3.0",
         "eslint": "7.32.0",
         "eslint-config-next": "11.1.2",
@@ -3769,6 +3770,20 @@
       "dev": true,
       "dependencies": {
         "compare-func": "^2.0.0",
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-5.0.0.tgz",
+      "integrity": "sha512-lCDbA+ZqVFQGUj7h9QBKoIpLhl8iihkO0nCTyRNzuXtcd7ubODpYB04IFy31JloiJgG0Uovu8ot8oxRzn7Nwtw==",
+      "dev": true,
+      "dependencies": {
+        "compare-func": "^2.0.0",
+        "lodash": "^4.17.15",
         "q": "^1.5.1"
       },
       "engines": {
@@ -17612,6 +17627,17 @@
       "dev": true,
       "requires": {
         "compare-func": "^2.0.0",
+        "q": "^1.5.1"
+      }
+    },
+    "conventional-changelog-conventionalcommits": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-5.0.0.tgz",
+      "integrity": "sha512-lCDbA+ZqVFQGUj7h9QBKoIpLhl8iihkO0nCTyRNzuXtcd7ubODpYB04IFy31JloiJgG0Uovu8ot8oxRzn7Nwtw==",
+      "dev": true,
+      "requires": {
+        "compare-func": "^2.0.0",
+        "lodash": "^4.17.15",
         "q": "^1.5.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,11 @@
 {
   "name": "dazedbear.github.io",
   "version": "4.15.1",
+  "homepage": "https://github.com/dazedbear/dazedbear.github.io",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:dazedbear/dazedbear.github.io.git"
+  },
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -29,7 +34,7 @@
       [
         "@semantic-release/commit-analyzer",
         {
-          "preset": "angular",
+          "preset": "conventionalcommits",
           "releaseRules": [
             {
               "breaking": true,
@@ -85,69 +90,80 @@
       [
         "@semantic-release/release-notes-generator",
         {
-          "preset": "angular",
-          "parserOpts": {
-            "noteKeywords": [
-              "BREAKING CHANGE",
-              "BREAKING CHANGES",
-              "BREAKING"
-            ]
-          },
+          "preset": "conventionalcommits",
           "presetConfig": {
+            "header": "Changelog",
             "types": [
               {
                 "type": "feat",
-                "section": "Features"
+                "section": "Features",
+                "hidden": false
               },
               {
                 "type": "fix",
-                "section": "Bug Fixes"
+                "section": "Bug Fixes",
+                "hidden": false
               },
               {
                 "type": "docs",
-                "section": "Documentation"
+                "section": "Documentation",
+                "hidden": false
               },
               {
                 "type": "style",
-                "section": "Others"
+                "section": "Others",
+                "hidden": false
               },
               {
                 "type": "refactor",
-                "section": "Others"
+                "section": "Others",
+                "hidden": false
               },
               {
                 "type": "patch",
-                "section": "Hotfix"
+                "section": "Hotfix",
+                "hidden": false
               },
               {
                 "type": "perf",
-                "section": "Performance"
+                "section": "Performance",
+                "hidden": false
               },
               {
                 "type": "test",
-                "section": "Testing"
+                "section": "Testing",
+                "hidden": false
               },
               {
                 "type": "build",
-                "section": "Build"
+                "section": "Build",
+                "hidden": false
               },
               {
                 "type": "ci",
-                "section": "CI/CD"
+                "section": "CI/CD",
+                "hidden": false
               },
               {
                 "type": "chore",
-                "section": "Others"
+                "section": "Others",
+                "hidden": false
               },
               {
                 "type": "revert",
-                "section": "Others"
+                "section": "Others",
+                "hidden": false
               }
             ]
           }
         }
       ],
-      "@semantic-release/changelog",
+      [
+        "@semantic-release/changelog",
+        {
+          "changelogTitle": "Changelog"
+        }
+      ],
       [
         "@semantic-release/npm",
         {
@@ -213,6 +229,7 @@
     "@types/react": "^16.9.17",
     "@types/react-redux": "^7.1.21",
     "autoprefixer": "^10.4.7",
+    "conventional-changelog-conventionalcommits": "^5.0.0",
     "cz-conventional-changelog": "^3.3.0",
     "eslint": "7.32.0",
     "eslint-config-next": "11.1.2",


### PR DESCRIPTION
## Goal

<!-- Please describe what's the main purpose of this PR -->

Fix empty release note content issue. https://github.com/dazedbear/dazedbear.github.io/commit/e16ca6d1165d1599a83b4e4ffd6419a191973277

## Knowledge Transfer / Notes

<!-- Anything worth sharing? E.g. when introducing new technologies, libraries, design patterns, techniques, best practices or any learnings while working on this change. -->

The preset `angular` doesn't support `types` fields to customize the section names in `CHANGELOG.md` file, so I have to use another preset `conventionalcommits` to meet my requirement.

https://github.com/semantic-release/release-notes-generator/issues/153#issuecomment-555152563

