### PR TITLE
ci: split prod schedule failsafe generation

### DIFF
--- a/.github/workflows/failsafe.yml
+++ b/.github/workflows/failsafe.yml
@@ -21,7 +21,7 @@ jobs:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
   failsafe-generation-stage:
-    name: Failsafe Page Generation Stage
+    name: Failsafe Page Generation (Stage Deployment)
     runs-on: ubuntu-latest
     if: contains(github.ref, 'refs/pull')
     needs: wait-for-deployment
@@ -41,10 +41,29 @@ jobs:
         run: npm run task:failsafe
 
   failsafe-generation-production:
-    name: Failsafe Page Generation Production
+    name: Failsafe Page Generation (Production Deployment)
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     needs: wait-for-deployment
+    env:
+      NEXT_PUBLIC_APP_ENV: production
+    steps:
+      - name: Checkout project source
+        uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+      - name: Install dependency
+        run: npm install --legacy-peer-deps
+      - name: Run failsafe generation
+        run: npm run task:failsafe
+
+  failsafe-generation-production-schedule:
+    name: Failsafe Page Generation (Production Schedule)
+    runs-on: ubuntu-latest
+    # skip waiting for deployment for production schedule generation
+    if: github.ref == 'refs/heads/main' && github.event_name == 'schedule'
     env:
       NEXT_PUBLIC_APP_ENV: production
     steps:


### PR DESCRIPTION
## Goal

<!-- Please describe what's the main purpose of this PR -->

The production schedule failsafe generation job was broken because the job waited for the canceled Vercel build. (committed by semantic-release-bot). To fix this issue, I split the production schedule failsafe generation into a separate job.

- https://github.com/dazedbear/dazedbear.github.io/runs/7711727407?check_suite_focus=true
- https://vercel.com/dazedbear/dazedbear-github-io/5NbzSZd5HQGsjxJwRSRxFwUTUbhn

<img width="1307" alt="截圖 2022-08-07 下午10 57 28" src="https://user-images.githubusercontent.com/8896191/183297354-02965a21-8bee-4adc-a0b9-06f56bdc8d53.png">

<img width="1256" alt="截圖 2022-08-07 下午10 57 52" src="https://user-images.githubusercontent.com/8896191/183297362-ce2d8ad9-0130-4a7e-8fd4-d406f85999f5.png">


## Reference

<!-- Anything reference can be placed here -->

- [github action context](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context)
- [github action `schedule` event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule)
- [github action `push` event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push)