### PR TITLE
ci: skip wait for deployment for schedule job

### DIFF
--- a/.github/workflows/failsafe.yml
+++ b/.github/workflows/failsafe.yml
@@ -17,6 +17,7 @@ env:
 jobs:
   wait-for-deployment:
     uses: ./.github/workflows/vercel-deployment.yml
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
     secrets:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 


### PR DESCRIPTION
## Goal

<!-- Please describe what's the main purpose of this PR -->

skip `wait-for-deployment` job for schedule event

https://github.com/dazedbear/dazedbear.github.io/actions/runs/2814258821
<img width="735" alt="截圖 2022-08-08 上午9 42 31" src="https://user-images.githubusercontent.com/8896191/183322183-23c8ed56-fea0-4102-93eb-f247f64d5bf9.png">


Related to https://github.com/dazedbear/dazedbear.github.io/pull/48.