### PR TITLE
feat: add about page served by notion

### DIFF
--- a/site.config.js
+++ b/site.config.js
@@ -64,6 +64,11 @@ module.exports = {
   },
   navigation: [
     {
+      label: 'About',
+      page: '/about',
+      enabled: true,
+    },
+    {
       label: 'Music',
       page: '/music',
       enabled: true,
@@ -83,6 +88,15 @@ module.exports = {
     token: env.get('NOTION_TOKEN').asString(),
     // you can insert any notion index page you need here.
     pages: {
+      about: {
+        enabled: true,
+        navMenuTitle: 'About 關於我',
+        pageId: normalizeId(env.get('ABOUT_PAGE_ID').asString()),
+        requiredEnv: [
+          'ABOUT_PAGE_ID',
+        ],
+        type: 'page',
+      },
       article: {
         collectionId: normalizeId(env.get('ARTICLE_COLLECTION_ID').asString()),
         collectionViewId: normalizeId(

--- a/site.config.js
+++ b/site.config.js
@@ -15,10 +15,8 @@ const normalizeId = id => {
   )}-${id.substr(20)}`
 }
 
-const currentEnv = env
-  .get('NEXT_PUBLIC_APP_ENV')
-  .default('production')
-  .asString()
+// env-var cannot read `NEXT_PUBLIC_` prefix env variables on client-side
+const currentEnv = process.env.NEXT_PUBLIC_APP_ENV || 'production';
 module.exports = {
   aws: {
     s3bucket: env.get('AWS_S3_BUCKET').asString(),

--- a/site.config.js
+++ b/site.config.js
@@ -96,6 +96,7 @@ module.exports = {
           'ARTICLE_COLLECTION_ID',
           'ARTICLE_COLLECTION_VIEW_ID',
         ],
+        type: 'stream',
       },
       coding: {
         collectionId: normalizeId(env.get('CODING_COLLECTION_ID').asString()),
@@ -110,6 +111,7 @@ module.exports = {
           'CODING_COLLECTION_ID',
           'CODING_COLLECTION_VIEW_ID',
         ],
+        type: 'stream',
       },
       music: {
         collectionId: normalizeId(env.get('MUSIC_COLLECTION_ID').asString()),
@@ -124,6 +126,7 @@ module.exports = {
           'MUSIC_COLLECTION_ID',
           'MUSIC_COLLECTION_VIEW_ID',
         ],
+        type: 'stream',
       },
     },
     pagination: {

--- a/src/libs/client/slices/index.ts
+++ b/src/libs/client/slices/index.ts
@@ -1,9 +1,11 @@
 import { combineReducers } from 'redux'
 import layout from './layout'
 import stream from './stream'
+import page from './page'
 
 const rootReducer = combineReducers({
   layout,
+  page,
   stream,
 })
 

--- a/src/libs/client/slices/page.ts
+++ b/src/libs/client/slices/page.ts
@@ -1,0 +1,63 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { HYDRATE } from 'next-redux-wrapper'
+import get from 'lodash/get'
+import cloneDeep from 'lodash/cloneDeep'
+import merge from 'lodash/merge'
+import isEmpty from 'lodash/isEmpty'
+import { notion } from '../../../../site.config'
+
+const slideName = 'page';
+
+interface ContentState {}
+
+export interface ActionPayloadState {
+  name: string
+  data: ContentState
+}
+
+interface PageState {
+  [propName: string]: ContentState
+}
+
+type getInitialStateFn = () => PageState
+
+// generate initState from site.config.js notion.pages
+const getInitialState: getInitialStateFn = () => {
+  return Object.keys(notion.pages).reduce((initState, name) => {
+    const pageConfig = notion.pages[name]
+    if (pageConfig.enabled && pageConfig.type === slideName) {
+      initState[name] = {}
+    }
+    return initState
+  }, {})
+}
+
+/**
+ * Slices
+ */
+const PageSlice = createSlice({
+  name: slideName,
+  initialState: getInitialState(),
+  reducers: {
+    updateSinglePage(state, action: PayloadAction<ActionPayloadState>) {
+      const { name, data } = action.payload
+      state[name] = data
+    },
+  },
+  extraReducers: {
+    [HYDRATE]: (state, action) => {
+      const retainState = Object.keys(state).reduce((composite, name) => {
+        const currentState = get(state, [name])
+        if (!isEmpty(currentState)) {
+          composite[name] = cloneDeep(currentState)
+        }
+        return composite
+      }, {})
+      merge(state, action.payload[slideName], retainState)
+    },
+  },
+})
+
+export const { updateSinglePage } = PageSlice.actions
+
+export default PageSlice.reducer

--- a/src/libs/client/slices/stream.ts
+++ b/src/libs/client/slices/stream.ts
@@ -40,7 +40,7 @@ const getInitialState: getInitialStateFn = () => {
   }
   return Object.keys(notion.pages).reduce((initState, name) => {
     const pageConfig = notion.pages[name]
-    if (pageConfig.enabled) {
+    if (pageConfig.enabled && pageConfig.type === 'stream') {
       initState[name] = Object.assign({}, defaultContentState)
     }
     return initState

--- a/src/libs/constant.js
+++ b/src/libs/constant.js
@@ -1,4 +1,5 @@
 module.exports = {
+  ABOUT_PAGE: 'AboutPage',
   PAGE_TYPE_ARTICLE_LIST_PAGE: 'ArticleListPage',
   PAGE_TYPE_ARTICLE_SINGLE_PAGE: 'ArticleSinglePage',
   PAGE_TYPE_ERROR_PAGE: 'ErrorPage',

--- a/src/libs/server/page.ts
+++ b/src/libs/server/page.ts
@@ -149,7 +149,7 @@ export const fetchArticleStream = async ({
       req,
     }
     log(options)
-    throw 'Required info are invalid in fetchArticles.'
+    throw 'Required info are invalid in fetchArticleStream.'
   }
 
   const response = await getNotionPage(id)
@@ -157,28 +157,51 @@ export const fetchArticleStream = async ({
 }
 
 /**
- * fetch article from upstream API
+ * fetch single page content from upstream API
  * @param {object} req
  * @param {string} pageName
  * @returns {object} raw data from upstream API
  */
-export const fetchSingleArticleStream = async (
-  req: GetServerSidePropsRequest,
-  pageId: string,
-  category: string
-): Promise<ExtendedRecordMap> => {
-  if (!pageId) {
+export const fetchSinglePage = async ({
+  req,
+  pageName,
+  pageId,
+  category,
+}: {
+  req?: GetServerSidePropsRequest
+  pageName?: NotionPageName
+  pageId?: string
+  category?: string
+}): Promise<ExtendedRecordMap> => {
+  let isRequiredInfoReady = false
+  let message = ''
+  let id: string = ''
+
+  if (pageName) {
+    id = get(notion, ['pages', pageName, 'pageId'])
+    const pageEnabled: boolean = get(notion, ['pages', pageName, 'enabled'])
+    if (id && pageEnabled) {
+      isRequiredInfoReady = true
+    } else {
+      message = `required info are invalid | pageId: ${pageId} | pageEnabled: ${pageEnabled}`
+    }
+  } else if (pageId) {
+    id = pageId
+    isRequiredInfoReady = true
+  }
+
+  if (!isRequiredInfoReady) {
     const options: logOption = {
-      category,
-      message: `required info are invalid | pageId: ${pageId}`,
+      category: category || 'fetchSinglePage',
+      message,
       level: 'error',
       req,
     }
     log(options)
-    throw 'Required info are invalid in fetchArticles.'
+    throw 'Required info are invalid in fetchSinglePage.'
   }
 
-  const response = await getNotionPage(pageId)
+  const response = await getNotionPage(id)
   return response
 }
 

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -164,7 +164,7 @@ const AboutPage = ({ hasError, pageName }) => {
 
   return (
     <div
-      id="about-page"
+      id="notion-about-page"
       data-namespace={pageName}
       className="pt-24 lg:pt-12 flex flex-row flex-grow flex-nowrap max-w-1100 py-0 px-5 my-0 mx-auto"
     >

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -1,0 +1,184 @@
+// for Prism.js language highlight
+import 'prismjs'
+import 'prismjs/components/prism-markup'
+import 'prismjs/components/prism-markup-templating'
+import 'prismjs/components/prism-css'
+import 'prismjs/components/prism-css-extras'
+import 'prismjs/components/prism-javascript'
+import 'prismjs/components/prism-typescript'
+// prism-php has a dependency: prism-markup-templating.
+// see: https://github.com/PrismJS/prism/issues/1400#issuecomment-485847919
+import 'prismjs/components/prism-php'
+import 'prismjs/components/prism-php-extras'
+import 'prismjs/components/prism-bash'
+import 'prismjs/components/prism-shell-session'
+import 'prismjs/components/prism-json'
+import 'prismjs/components/prism-vim'
+import 'prismjs/components/prism-graphql'
+import 'prismjs/components/prism-jsx'
+import 'prismjs/components/prism-tsx'
+import 'prismjs/components/prism-yaml'
+import 'prismjs/components/prism-docker'
+import 'prismjs/components/prism-log'
+
+import { GetServerSideProps } from 'next'
+import Link from 'next/link'
+import Error from 'next/error'
+import dynamic from 'next/dynamic'
+import get from 'lodash/get'
+import cloneDeep from 'lodash/cloneDeep'
+import { ExtendedRecordMap } from 'notion-types'
+import { Code, Collection, CollectionRow, NotionRenderer } from 'react-notion-x'
+
+import { notion, pageProcessTimeout } from '../../site.config'
+import {
+  FAILSAFE_PAGE_GENERATION_QUERY,
+  ABOUT_PAGE,
+} from '../libs/constant'
+import { mapNotionPageLinkUrl } from '../libs/notion'
+import log from '../libs/server/log'
+import wrapper from '../libs/client/store'
+import { updateSinglePage } from '../libs/client/slices/page'
+import { useAppSelector, useRemoveLinks } from '../libs/client/hooks'
+import {
+  showCommonPage,
+  fetchSinglePage,
+  isValidPageName,
+  executeFunctionWithTimeout,
+  setSSRCacheHeaders,
+} from '../libs/server/page'
+import {
+  transformSinglePage,
+  transformPageActionPayload,
+} from '../libs/server/transformer'
+import { logOption } from '../../types'
+
+const pageName = 'about';
+
+export const getServerSideProps: GetServerSideProps = wrapper.getServerSideProps(
+  store => async ({ query, req, res }) => {
+    // disable page timeout when failsafe generation mode (?fsg=1)
+    const timeout =
+      query[FAILSAFE_PAGE_GENERATION_QUERY] === '1' ? 0 : pageProcessTimeout
+    const props = await executeFunctionWithTimeout(
+      async () => {
+        if (!isValidPageName(pageName)) {
+          const options: logOption = {
+            category: ABOUT_PAGE,
+            message: `invalid page | pageName: ${pageName}`,
+            level: 'error',
+            req,
+          }
+          log(options)
+          return showCommonPage(req, res, 'notFound', pageName)
+        }
+
+        try {
+          const response = await fetchSinglePage({
+            req,
+            pageName,
+            category: ABOUT_PAGE,
+          })
+          const pageContent = await transformSinglePage(response)
+          
+          // save SSR fetch page contents to redux store
+          const payload = transformPageActionPayload(pageName, pageContent)
+          const action = updateSinglePage(payload)
+          store.dispatch(action)
+
+          const options: logOption = {
+            category: 'page',
+            message: `dumpaccess to /${pageName}`,
+            level: 'info',
+            req,
+          }
+          log(options)
+          setSSRCacheHeaders(res)
+          return {
+            props: {
+              pageName,
+            },
+          }
+        } catch (err) {
+          const options: logOption = {
+            category: ABOUT_PAGE,
+            message: err,
+            level: 'error',
+            req,
+          }
+          log(options)
+          return showCommonPage(req, res, 'error', pageName)
+        }
+      },
+      timeout,
+      duration => {
+        const options: logOption = {
+          category: ABOUT_PAGE,
+          message: `page processing timeout | duration: ${duration} ms`,
+          level: 'warn',
+          req,
+        }
+        log(options)
+        return showCommonPage(req, res, 'error', pageName)
+      },
+      ABOUT_PAGE
+    )
+    return props
+  }
+)
+
+const NotionComponentMap: object = {
+  code: Code,
+  collection: Collection,
+  collectionRow: CollectionRow,
+  equation: () => null, // we don't have math equation in articles, so we don't need this
+  modal: dynamic(() => import('react-notion-x').then(notion => notion.Modal), {
+    ssr: false,
+  }),
+  pageLink: props => (
+    <Link {...props}>
+      <a {...props} />
+    </Link>
+  ),
+  tweet: () => null,
+}
+
+const AboutPage = ({ hasError, pageName }) => {
+  const pageState = useAppSelector(state => state.page)
+  // disable links from notion table.
+  useRemoveLinks({
+    selector: '.notion-table a.notion-page-link',
+    condition: () => true,
+  })
+
+  if (hasError) {
+    return <Error statusCode={500} title="This page is broken" />
+  }
+
+  const blockId: string = get(notion, ['pages', pageName, 'pageId'])
+  const content: ExtendedRecordMap = get(pageState, [pageName])
+  const previewImagesEnabled: boolean = get(notion, ['previeImages', 'enable'])
+
+  // hack to temporarily fix "cannot assign type to read-only object" issue in react-notion-x
+  const recordMap = cloneDeep(content)
+
+  return (
+    <div
+      id="about-page"
+      data-namespace={pageName}
+      className="pt-24 lg:pt-12 flex flex-row flex-grow flex-nowrap max-w-1100 py-0 px-5 my-0 mx-auto"
+    >
+      <NotionRenderer
+        blockId={blockId}
+        fullPage={false}
+        recordMap={recordMap}
+        components={NotionComponentMap}
+        mapPageUrl={mapNotionPageLinkUrl.bind(this, pageName, recordMap)}
+        previewImages={previewImagesEnabled}
+        showCollectionViewDropdown={false}
+      />
+    </div>
+  )
+}
+
+export default AboutPage

--- a/src/pages/api/posts.ts
+++ b/src/pages/api/posts.ts
@@ -49,8 +49,9 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       'collectionViewId',
     ])
     const pageEnabled = get(notion, ['pages', pageName, 'enabled'])
+    const pageType = get(notion, ['pages', pageName, 'type'])
 
-    if (!pageEnabled) {
+    if (!pageEnabled || pageType !== 'stream') {
       log({
         category,
         message: `posts data not found because this page is disabled \nquery params = ${JSON.stringify(

--- a/src/styles/notion.css
+++ b/src/styles/notion.css
@@ -96,3 +96,13 @@
   overflow-x: scroll;
   overflow-y: visible;
 }
+
+/**
+ * for about page: #app #notion-about-page ...
+ */
+#app #notion-about-page .notion-page {
+  @apply pt-6 pb-5 lg:pt-12 lg:pb-10 px-0 m-0;
+}
+#app #notion-about-page .notion-page h2:first-of-type {
+  @apply mt-0;
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -49,6 +49,8 @@ export interface ArticleStream {
   total?: number
 }
 
+export interface SinglePage {}
+
 export type CacheClientServingStatus =
   | 'default'
   | 'initializing'


### PR DESCRIPTION
## Goal

<!-- Please describe what's the main purpose of this PR -->
- fix client-side `currentEnv` is always `production` on local development
- add about page served by notion

## Preview
<img width="600" alt="截圖 2022-08-13 上午12 56 20" src="https://user-images.githubusercontent.com/8896191/184407159-6cb5d089-23fb-4de3-ad6f-5157310ee4c0.png">
<img width="250" alt="截圖 2022-08-13 上午12 55 59" src="https://user-images.githubusercontent.com/8896191/184407204-ba0b3733-bcc7-47b6-81ee-f9be2f74beae.png">

