### PR TITLE
ci: separate lighthouse schedule job and audit /about page

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           urls: |
             https://www.dazedbear.pro/
+            https://www.dazedbear.pro/about
             https://www.dazedbear.pro/music
             https://www.dazedbear.pro/coding
             https://www.dazedbear.pro/article
@@ -75,6 +76,7 @@ jobs:
         with:
           urls: |
             https://www.dazedbear.pro/
+            https://www.dazedbear.pro/about
             https://www.dazedbear.pro/music
             https://www.dazedbear.pro/coding
             https://www.dazedbear.pro/article

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -10,13 +10,63 @@ on:
 
 jobs:
   wait-for-deployment:
-    uses: dazedbear/dazedbear.github.io/.github/workflows/vercel-deployment.yml@main
+    uses: ./.github/workflows/vercel-deployment.yml
+    if: github.event_name == 'push'
     secrets:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
   lighthouse-production:
     needs: wait-for-deployment
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Audit URLs using Lighthouse
+        id: lighthouseci
+        uses: treosh/lighthouse-ci-action@v8
+        with:
+          urls: |
+            https://www.dazedbear.pro/
+            https://www.dazedbear.pro/music
+            https://www.dazedbear.pro/coding
+            https://www.dazedbear.pro/article
+          uploadArtifacts: false
+          temporaryPublicStorage: false
+      - name: Upload Lighthouse Report JSON files to Gist
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.GIST_TOKEN }}
+          script: |
+            const fs = require('fs')
+            const path = require('path')
+
+            const reportFileExtension = '.report.json'
+            const reportBaseUrl = 'https://googlechrome.github.io/lighthouse/viewer?gist='
+
+            const reportDir = '${{ steps.lighthouseci.outputs.resultsPath }}'
+            const reportPaths = (fs.readdirSync(reportDir) || []).filter(filename => filename.includes(reportFileExtension))
+            const createGistPromises = reportPaths.map(filename => {
+              const filePath = path.join(reportDir, filename)
+              const content = fs.readFileSync(filePath, 'utf-8')
+              const files = {
+                [filename]: { 
+                  content
+                }
+              }
+              return github.gists.create({ files })
+                .then(newGist => {
+                  core.info(`${reportBaseUrl}${newGist.data.id}`);
+                })
+            })
+            core.startGroup('Deploy to Gist')
+            core.info('Lighthouse Reports:')
+            await Promise.all(createGistPromises)
+            core.endGroup()
+
+  lighthouse-production-schedule:
+    runs-on: ubuntu-latest
+    # skip waiting for deployment for production schedule generation
+    if: github.ref == 'refs/heads/main' && github.event_name == 'schedule'
     steps:
       - uses: actions/checkout@v2
       - name: Audit URLs using Lighthouse


### PR DESCRIPTION
## Goal

<!-- Please describe what's the main purpose of this PR -->
- separate lighthouse schedule job to fix the broken job

https://github.com/dazedbear/dazedbear.github.io/runs/7716154172?check_suite_focus=true#step:4:11

<img width="1680" alt="截圖 2022-08-13 上午1 33 35" src="https://user-images.githubusercontent.com/8896191/184412914-a72f764c-dfb5-441b-82f3-ae61d0979300.png">

- audit `/about` page

