### PR TITLE
feat: add custom meta title, description, image for all pages

### DIFF
--- a/site.config.js
+++ b/site.config.js
@@ -60,7 +60,7 @@ module.exports = {
   meta: {
     title: 'DazedBear Studio',
     description: 'Web。Music。Creative Coding',
-    image: '',
+    image: 'https://static.dazedbear.pro/website-thumbnail.png',
   },
   navigation: [
     {
@@ -156,10 +156,12 @@ module.exports = {
   pages: {
     index: {
       enabled: true,
+      title: '首頁',
       page: '/',
     },
     maintain: {
       enabled: true,
+      title: '頁面維護中',
       page: '/maintain',
     },
   },

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,10 +1,9 @@
 import Image from 'next/image'
 import Link from 'next/link'
-import Head from 'next/head'
 import classnames from 'classnames'
 import ExtLink from './ext-link'
 import { meta, navigation as navItems } from '../../site.config'
-import { getCurrentPageTitle, isActivePage } from '../libs/util'
+import { isActivePage } from '../libs/util'
 import faviconIcon from '../../public/favicon.ico'
 
 const themeClassMap = {
@@ -27,7 +26,6 @@ const themeClassMap = {
 
 const Header = () => {
   const currentTheme = isActivePage('/') ? 'modern' : 'classic'
-  const titlePre = getCurrentPageTitle()
   const linkClass =
     'box-border items-center border-0 border-white text-base m-0 p-2.5 justify-center flex flex-row flex-nowrap h-12 z-10000 transition duration-300 lg:h-8 font-normal lg:py-1.5 lg:px-2.5'
   const liniInActiveClass = themeClassMap[currentTheme]?.linkInActive || ''
@@ -43,14 +41,6 @@ const Header = () => {
     >
       <div className="my-0 mx-auto max-w-1400 py-0 px-5">
         <header className="flex relative text-left flex-nowrap flex-row">
-          <Head>
-            <title>
-              {titlePre ? `${titlePre} · ${meta.title}` : meta.title}
-            </title>
-            <meta name="description" content={meta.description} />
-            <meta name="og:title" content={meta.title} />
-            <meta property="og:image" content={meta.image} />
-          </Head>
           <Link href="/">
             <a className="items-center border-0 border-white flex flex-row flex-nowrap h-9 z-10000">
               <div className="h-9 w-9 mr-2.5 box-content relative">

--- a/src/libs/server/transformer.ts
+++ b/src/libs/server/transformer.ts
@@ -307,7 +307,7 @@ export const transformArticleSinglePageMeta = (
 
   const pageMeta = {
     // description: '', TODO: add description later
-    image: property.PageCover,
+    // image: property.PageCover, TODO: notion image url doesn't work
     title: property.PageTitle
   };
 

--- a/src/libs/util.ts
+++ b/src/libs/util.ts
@@ -1,5 +1,7 @@
 import { useRouter } from 'next/router'
-import { navigation as navItems } from '../../site.config'
+import get from 'lodash/get'
+import { notion, meta as commonMeta, pages as staticPages } from '../../site.config'
+import type { PageMeta } from '../../types'
 
 /**
  * get formatted date string
@@ -32,8 +34,26 @@ export const isActivePage = page => {
  * get title of current page from navigation config
  * @returns {string} title of current page
  */
-export const getCurrentPageTitle = () => {
-  const { pathname } = useRouter()
-  return navItems.find(({ page }) => page !== '/' && pathname.includes(page))
-    ?.label
+export const getPageMeta = (pageMeta: PageMeta = {}): PageMeta => {
+  const { asPath } = useRouter();
+  const meta = {
+    title: commonMeta.title,
+    description: commonMeta.description,
+    image: commonMeta.image
+  };
+
+  // pageMeta is for SSR pages override
+  // add fallback logic for static pages & SSR pages without meta override
+  const page = asPath === '/' ? 'index' : asPath.split('/').filter(Boolean)[0];
+  const pageTitle = pageMeta.title || get(staticPages, [page, 'title']) || get(notion, ['pages', page, 'navMenuTitle']);
+  if (pageTitle) {
+    meta.title = `${pageTitle} · ${commonMeta.title}`;
+  }
+  if (pageMeta.description) {
+    meta.description = pageMeta.description;
+  }
+  if (pageMeta.image) {
+    meta.image = pageMeta.image;
+  }
+  return meta;
 }

--- a/src/pages/[pageName]/[pageSlug].tsx
+++ b/src/pages/[pageName]/[pageSlug].tsx
@@ -61,6 +61,7 @@ import {
   transformArticleStream,
   transformArticleStreamPreviewImages,
   transformSingleArticle,
+  transformArticleSinglePageMeta,
   transformMenuItems,
   transformStreamActionPayload,
   transformTableOfContent,
@@ -124,6 +125,7 @@ export const getServerSideProps: GetServerSideProps = wrapper.getServerSideProps
           articleStream = merge(articleStream, singleArticle)
 
           const menuItems = transformMenuItems(pageName, articleStream)
+          const meta = transformArticleSinglePageMeta(articleStream, articleId)
           const toc = transformTableOfContent(articleStream, articleId)
 
           // save SSR fetch stream article contents to redux store
@@ -142,6 +144,7 @@ export const getServerSideProps: GetServerSideProps = wrapper.getServerSideProps
           return {
             props: {
               menuItems,
+              meta,
               pageId: idToUuid(articleId),
               pageName,
               toc,

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -13,7 +13,9 @@ import {
   useInitLogRocket,
 } from '../libs/client/hooks'
 import wrapper from '../libs/client/store'
+import { getPageMeta } from '../libs/util'
 import Router from 'next/router'
+import Head from 'next/head'
 import NProgress from 'nprogress'
 
 // loading progress bar
@@ -26,8 +28,15 @@ const App = ({ Component, pageProps }) => {
   useInitLogRocket()
   useResizeHandler()
   useCodeSyntaxHighlight()
+  const { title, description, image } = getPageMeta(pageProps.meta);
   return (
     <div id="app">
+      <Head>
+        <title>{title}</title>
+        <meta name="description" content={description} />
+        <meta name="og:title" content={title} />
+        <meta property="og:image" content={image} />
+      </Head>
       <Header />
       <div id="main-content">
         <Component {...pageProps} />

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -56,3 +56,9 @@ export type CacheClientServingStatus =
   | 'initializing'
   | 'running'
   | 'terminated'
+
+export interface PageMeta {
+  title?: string;
+  description?: string;
+  image?: string;
+}


### PR DESCRIPTION
## Goal

<!-- Please describe what's the main purpose of this PR -->

feat: add custom meta title, description, image for all pages

Note: the `image` and `description` override for the article single page are still under design so that I will have a separate PR for that.

https://github.com/dazedbear/dazedbear.github.io/pull/52/files#diff-7698e5eeea40d6d8a5df0de4f14aacb6f6f9832f6eca65dcfb9e3050989a04bfR309-R310

## Reference

<!-- Anything reference can be placed here -->
- website meta tag reference: https://nicechord.com/
- website meta tag reference: https://secview.io/
- https://nextjs.org/docs/advanced-features/custom-document#caveats