### PR TITLE
fix: remove the spacing on the top of desktop notion article pages

### DIFF
--- a/src/styles/notion.css
+++ b/src/styles/notion.css
@@ -15,7 +15,7 @@
  * for global notion style override: #app ...
  */
 #app .notion-page {
-  @apply my-0 mb-0 mt-14 px-0 pt-0 pb-5 lg:pt-12 lg:pb-10;
+  @apply my-0 mb-0 mt-14 px-0 pt-0 pb-5 lg:mt-12 lg:pb-10;
 }
 
 #app .notion-viewport {


### PR DESCRIPTION
## Goal

<!-- Please describe what's the main purpose of this PR -->

fix the spacing on the top of notion article pages

## Preview

### Before

<img width="600" alt="截圖 2022-09-10 下午5 47 45" src="https://user-images.githubusercontent.com/8896191/189478400-718b0cf7-1d95-4124-913e-391c165979dd.png">

<img width="600" alt="截圖 2022-09-10 下午5 47 29" src="https://user-images.githubusercontent.com/8896191/189478405-bff9f001-bab8-4d8e-9ade-9659fedfa74a.png">



### After

<img width="600" alt="截圖 2022-09-10 下午5 47 51" src="https://user-images.githubusercontent.com/8896191/189478409-277b68aa-2405-45d8-94f2-7a50854dde83.png">

<img width="600" alt="截圖 2022-09-10 下午5 47 34" src="https://user-images.githubusercontent.com/8896191/189478414-2b1df0d0-5c5c-4804-bd4d-7c366c6e9c15.png">


