### PR TITLE
chore: replace GA4 gtag tracking with GTM

### DIFF
--- a/site.config.js
+++ b/site.config.js
@@ -233,7 +233,11 @@ module.exports = {
   trackingSettings: {
     googleAnalytics: {
       enable: true,
-      id: 'G-J8DQ8XDQ71', // GA4 id: G-J8DQ8XDQ71, current id: UA-83233420-3
+      id: 'G-J8DQ8XDQ71',
+    },
+    googleTagManager: {
+      enable: true,
+      id: 'GTM-KS2L2F3',
     },
     microsoftClarity: {
       enable: true,

--- a/site.config.js
+++ b/site.config.js
@@ -231,10 +231,6 @@ module.exports = {
     },
   },
   trackingSettings: {
-    googleAnalytics: {
-      enable: true,
-      id: 'G-J8DQ8XDQ71',
-    },
     googleTagManager: {
       enable: true,
       id: 'GTM-KS2L2F3',

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -24,23 +24,6 @@ class MyDocument extends Document {
               }}
             />
           )}
-          {!isLocal && trackingSettings?.googleAnalytics?.enable && (
-            <>
-              <script
-                async
-                src={`https://www.googletagmanager.com/gtag/js?id=${trackingSettings?.googleAnalytics?.id}`}
-              />
-              <script
-                dangerouslySetInnerHTML={{
-                  __html: `
-                    window.dataLayer = window.dataLayer || [];
-                    function gtag(){dataLayer.push(arguments);}
-                    gtag('js', new Date());
-                    gtag('config', '${trackingSettings?.googleAnalytics?.id}');`,
-                }}
-              />
-            </>
-          )}
           {!isLocal && trackingSettings?.googleTagManager?.enable && (
             <script
               dangerouslySetInnerHTML={{

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -41,6 +41,20 @@ class MyDocument extends Document {
               />
             </>
           )}
+          {!isLocal && trackingSettings?.googleTagManager?.enable && (
+            <script
+              dangerouslySetInnerHTML={{
+                __html: `
+                <!-- Google Tag Manager -->
+                <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+                new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+                j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+                'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+                })(window,document,'script','dataLayer','${trackingSettings?.googleTagManager?.id}');</script>
+                <!-- End Google Tag Manager -->`,
+              }}
+            />
+          )}
           {communityFeatures?.facebookChat?.enable && (
             <script
               dangerouslySetInnerHTML={{
@@ -77,6 +91,17 @@ class MyDocument extends Document {
                 }}
               />
             </>
+          )}
+          {!isLocal && trackingSettings?.googleTagManager?.enable && (
+            <script
+              dangerouslySetInnerHTML={{
+                __html: `
+                <!-- Google Tag Manager (noscript) -->
+                <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=${trackingSettings?.googleTagManager?.id}"
+                height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+                <!-- End Google Tag Manager (noscript) -->`,
+              }}
+            />
           )}
           <Main />
           <NextScript />


### PR DESCRIPTION
## Goal

<!-- Please describe what's the main purpose of this PR -->

Replace GA4 gtag tracking with GTM for better SEO tracking maintenance.

## Reference

<!-- Anything reference can be placed here -->

### Google Analytics / Google Tag Manager
- GA4 data filer: https://support.google.com/analytics/answer/10108813?hl=zh-Hant&ref_topic=9751244
- GTM + GA4 integration: https://support.google.com/tagmanager/answer/9442095?hl=zh-Hant
- GA4 filter internal traffic: https://support.google.com/analytics/answer/10104470

### Microsoft Clarity

- Filters: https://learn.microsoft.com/en-us/clarity/clarity-filters
- Regular Expression RE2: https://github.com/google/re2/wiki/Syntax