### PR TITLE
fix: broken gtm code

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -28,13 +28,11 @@ class MyDocument extends Document {
             <script
               dangerouslySetInnerHTML={{
                 __html: `
-                <!-- Google Tag Manager -->
-                <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+                (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
                 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
                 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-                })(window,document,'script','dataLayer','${trackingSettings?.googleTagManager?.id}');</script>
-                <!-- End Google Tag Manager -->`,
+                })(window,document,'script','dataLayer','${trackingSettings?.googleTagManager?.id}');`,
               }}
             />
           )}
@@ -76,15 +74,14 @@ class MyDocument extends Document {
             </>
           )}
           {!isLocal && trackingSettings?.googleTagManager?.enable && (
-            <script
-              dangerouslySetInnerHTML={{
-                __html: `
-                <!-- Google Tag Manager (noscript) -->
-                <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=${trackingSettings?.googleTagManager?.id}"
-                height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-                <!-- End Google Tag Manager (noscript) -->`,
-              }}
-            />
+            <noscript>
+              <iframe
+                src={`https://www.googletagmanager.com/ns.html?id=${trackingSettings?.googleTagManager?.id}`}
+                height="0"
+                width="0"
+                style={{ display: 'none', visibility: 'hidden' }}
+              />
+            </noscript>
           )}
           <Main />
           <NextScript />


### PR DESCRIPTION
## Goal

<!-- Please describe what's the main purpose of this PR -->

fix: broken gtm code

<img width="1680" alt="截圖 2022-10-01 下午3 56 53" src="https://user-images.githubusercontent.com/8896191/193399412-94b06fe6-be15-432f-9ff0-56a95d9ebbbd.png">

## Knowledge

can preview GTM on staging via [Google Tag Assistant Companion](https://chrome.google.com/webstore/detail/tag-assistant-companion/jmekfmbnaedfebfnmakmokmlfpblbfdm)

<img width="1119" alt="截圖 2022-10-01 下午3 59 37" src="https://user-images.githubusercontent.com/8896191/193399550-6cd62d61-de76-4d3f-ad9f-ca60456c0f42.png">
<img width="1680" alt="截圖 2022-10-01 下午4 00 03" src="https://user-images.githubusercontent.com/8896191/193399549-a32f6a40-1f7c-4851-9505-af33ebfe979f.png">
<img width="1680" alt="截圖 2022-10-01 下午4 01 01" src="https://user-images.githubusercontent.com/8896191/193399546-b78c463b-55a4-43d1-9120-8636f5df3604.png">

