### PR TITLE
feat: display property tags on notion single page

### DIFF
--- a/src/styles/notion.css
+++ b/src/styles/notion.css
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-class-pattern */
+
 /**
  * This file contains site-specifc style overrides for Notion elements from
  * react-notion-x.
@@ -122,8 +124,35 @@
   overflow-y: visible;
 }
 
-#app #notion-single-page .notion-collection-page-properties {
-  @apply hidden; /* hide page property meta */
+/**
+  styles override for notion single page property tags
+  class name: `notion-property-{type}`
+  https://github.com/NotionX/react-notion-x/blob/ad7f5f10f3ca88bd43f5fd5f9e07b6a669c2c1bb/packages/notion-types/src/core.ts#L40-L59
+ */
+#app
+  #notion-single-page
+  .notion-collection-page-properties
+  .notion-collection-row-value {
+  @apply p-0;
+}
+
+#app
+  #notion-single-page
+  .notion-collection-page-properties
+  .notion-collection-column-title,
+#app
+  #notion-single-page
+  .notion-collection-page-properties
+  .notion-collection-row-value
+  > span:not(.notion-property-select, .notion-property-multi_select) {
+  @apply hidden; /* only allow select, multi_select to displayed for property tags */
+}
+
+#app
+  #notion-single-page
+  .notion-collection-page-properties
+  .notion-collection-row {
+  @apply m-0 border-0;
 }
 
 /**


### PR DESCRIPTION
## Goal

<!-- Please describe what's the main purpose of this PR -->
display property tags on notion single page

<img width="1133" alt="Screen Shot 2023-01-26 at 4 08 12 PM" src="https://user-images.githubusercontent.com/8896191/214788396-df82ef07-c8b5-4320-b605-c4d59cfbf93e.png">

<img width="250" alt="Screen Shot 2023-01-26 at 4 08 51 PM" src="https://user-images.githubusercontent.com/8896191/214788409-50684dd6-8638-4caf-8764-c735f5f3bf38.png">

## Knowledge Transfer / Notes

<!-- Anything worth sharing? E.g. when introducing new technologies, libraries, design patterns, techniques, best practices or any learnings while working on this change. -->

The best solution is to use `:has()` pseudo-class to override the style of parent elements only when they have specific selectors within their children. However, it is not supported on Firefox.

- `:has()`: https://developer.mozilla.org/en-US/docs/Web/CSS/:has#browser_compatibility
- `:not()`: https://developer.mozilla.org/en-US/docs/Web/CSS/:not#browser_compatibility

```css
#app #notion-single-page .notion-collection-page-property {
  @apply hidden;
}
#app #notion-single-page .notion-collection-page-property:has(.notion-property-select, .notion-property-multi_select) {
  @apply flex;
}
```

Although there is a PostCSS plugin `css-has-pseudo` that can do some backward polyfill for unsupported browsers, it didn't work as expected for me.

- https://github.com/csstools/postcss-plugins/tree/main/plugins/css-has-pseudo
- https://philschatz.com/css-polyfills.js/

`postcss.config.js` is used by both Next.js and Tailwind CSS
- https://nextjs.org/docs/advanced-features/customizing-postcss-config
- https://tailwindcss.com/docs/using-with-preprocessors


