### PR TITLE
fix: increase cache ttls

### DIFF
--- a/site.config.js
+++ b/site.config.js
@@ -34,8 +34,8 @@ module.exports = {
     ttls: {
       // seconds
       default: 30,
-      sitemap: 86400,
-      notionPage: 86400,
+      sitemap: 86400 * 7,
+      notionPage: 86400 * 7,
       previewImage: 86400 * 30,
     },
     url: env.get('CACHE_CLIENT_API_URL').asString(),

--- a/src/pages/api/sitemap.ts
+++ b/src/pages/api/sitemap.ts
@@ -105,7 +105,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       req,
     })
 
-    // sitemap cache daily
+    // sitemap cache
     cacheConfig.forceRefresh = req.query[FORCE_CACHE_REFRESH_QUERY] === '1'
     const sitemapXmlKey = `sitemap_${dayjs.utc().format('YYYY-MM-DD')}`
     const sitemapXml = await cacheClient.proxy(


### PR DESCRIPTION
## Goal

<!-- Please describe what's the main purpose of this PR -->

I have received some failsafe redirection alerts daily since 2023/12/22 (https://github.com/dazedbear/dazedbear.github.io/pull/104 was merged on 2023/12/21). 

<img width="1403" alt="截圖 2023-12-27 下午9 22 18" src="https://github.com/dazedbear/dazedbear.github.io/assets/8896191/97a85f16-b7b3-4d8e-b824-456b1829363e">


The root cause is that I adjusted the failsafe generation from daily to weekly (which also triggers cache force refresh) but forgot to increase the Redis cache TTLs from 1 day to 7 days.

This PR is to increase the cache ttls from 1 day to 7 days.


