### PR TITLE
ci: adjust cronjob frequency to reduce the usage of KV

### DIFF
--- a/.github/workflows/failsafe.yml
+++ b/.github/workflows/failsafe.yml
@@ -5,8 +5,8 @@ on:
   pull_request:
     branches: [main]
   schedule:
-    # 18:00 GMT+8 every day
-    - cron: '0 10 * * *'
+    # 18:00 GMT+8 every Monday
+    - cron: '0 10 * * 1'
 
 env:
   AWS_REGION: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,9 +4,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  schedule:
-    # 18:30 GMT+8 every Monday and Thursday
-    - cron: '30 10 * * 1,4'
+  # schedule:
+  # 18:30 GMT+8 every Monday and Thursday
+  # - cron: '30 10 * * 1,4'
 
 jobs:
   wait-for-deployment:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -5,8 +5,8 @@ on:
   pull_request:
     branches: [main]
   schedule:
-    # 18:30 GMT+8 every day
-    - cron: '30 10 * * *'
+    # 18:30 GMT+8 every Monday and Thursday
+    - cron: '30 10 * * 1,4'
 
 jobs:
   wait-for-deployment:


### PR DESCRIPTION
## Goal

<!-- Please describe what's the main purpose of this PR -->
I got Vercel KV Data Transfer alert after merging https://github.com/dazedbear/dazedbear.github.io/pull/107.

<img src="https://github.com/dazedbear/dazedbear.github.io/assets/8896191/624bceaf-74e6-4906-b72b-db20db45c79a" width=350 />


Checking the usage data

- page request count and bandwidth increased since that PR
  - daily traffic from 0.5-1.5k to 1k-2k
  - outgoing bandwidth from 25 MB - 100 MB to 90 MB - 140 MB
- KV request count and data transfer increased since that PR
  - daily KV request traffic from <100 to 800
  - daily data transfer from 50 MB to 300 MB (limit: 256MB/month for free tier)

From the usage data, I know that the cost of these cronjobs is really high.
- failsafe generation: cost KV request count 800 & data transfer 250 MB each time
- functional testing: cost KV request count 250 & data transfer 100 MB each time


![截圖 2024-02-20 凌晨2 35 52](https://github.com/dazedbear/dazedbear.github.io/assets/8896191/0106e1cc-6c80-4e8c-aca2-679318145700)

![截圖 2024-02-20 凌晨2 36 13](https://github.com/dazedbear/dazedbear.github.io/assets/8896191/01f30cbf-834b-4b13-9a24-20355332861c)

KV

![截圖 2024-02-20 凌晨2 36 53](https://github.com/dazedbear/dazedbear.github.io/assets/8896191/798198c3-1b9a-41c3-af0d-44815a8f94a4)
![截圖 2024-02-20 凌晨2 36 43](https://github.com/dazedbear/dazedbear.github.io/assets/8896191/9322071d-9357-4b48-a1f9-58d8a6ccb0b9)


### Mitigation 

To mitigate this issue
1. reduce the failsafe page generation from daily to weekly
2. disable scheduled functional testing job
3. migrate the project from free tier to paid plan for better support and larger quota. (KV data transfer from 256 MB/month to 512 MB/month, 0.25USD per additional GB)
 
### Follow up

This points out some potential risks here.
1. the size of articles cache is too large.
2. cache doesn't work efficiently. More incoming request causes more KV usage.
4. need a smarter way to generate failsafe pages or it costs high to generate the same stale content
5. need a smarter way to cache such large amount of Notion articles (also should consider the limitation that all signed file URLs has 1 day expiration)

