### PR TITLE
feat: handle Vercel Data Cache Revalidation

### DIFF
--- a/src/app/[pageName]/[pageSlug]/page.tsx
+++ b/src/app/[pageName]/[pageSlug]/page.tsx
@@ -3,6 +3,7 @@ import { getNotionContent } from '../../notion/content'
 import { PAGE_TYPE_NOTION_ARTICLE_DETAIL_PAGE } from '../../../libs/constant'
 import { getPageMeta } from '../../../libs/util'
 import { getPageProperty } from '../../../libs/notion'
+import { handleForceCacheRefresh } from '../../../libs/server/page'
 import log from '../../../libs/server/log'
 
 export async function generateMetadata({ params, searchParams }) {
@@ -26,6 +27,10 @@ export async function generateMetadata({ params, searchParams }) {
 
 const ArticleListPage = async ({ params, searchParams }) => {
   const { pageName, pageSlug } = params
+  const pathname = `/${pageName}/${pageSlug}`
+
+  handleForceCacheRefresh(pathname, searchParams)
+
   const { menuItems, pageContent, pageId, toc } = await getNotionContent({
     pageType: PAGE_TYPE_NOTION_ARTICLE_DETAIL_PAGE,
     pageName,
@@ -35,7 +40,7 @@ const ArticleListPage = async ({ params, searchParams }) => {
 
   log({
     category: PAGE_TYPE_NOTION_ARTICLE_DETAIL_PAGE,
-    message: `dumpaccess to /${pageName}/${pageSlug}`,
+    message: `dumpaccess to ${pathname}`,
     level: 'info',
   })
   return (

--- a/src/app/[pageName]/page.tsx
+++ b/src/app/[pageName]/page.tsx
@@ -2,6 +2,7 @@ import NotionArticleListPage from '../notion/article-list-page'
 import { getNotionContent } from '../notion/content'
 import { PAGE_TYPE_NOTION_ARTICLE_LIST_PAGE } from '../../libs/constant'
 import { getPageMeta } from '../../libs/util'
+import { handleForceCacheRefresh } from '../../libs/server/page'
 import log from '../../libs/server/log'
 
 export async function generateMetadata({ params: { pageName } }) {
@@ -10,6 +11,10 @@ export async function generateMetadata({ params: { pageName } }) {
 
 const ArticleListPage = async ({ params, searchParams }) => {
   const { pageName } = params
+  const pathname = `/${pageName}`
+
+  handleForceCacheRefresh(pathname, searchParams)
+
   const { menuItems, articleStream } = await getNotionContent({
     pageType: PAGE_TYPE_NOTION_ARTICLE_LIST_PAGE,
     pageName,
@@ -18,7 +23,7 @@ const ArticleListPage = async ({ params, searchParams }) => {
 
   log({
     category: PAGE_TYPE_NOTION_ARTICLE_LIST_PAGE,
-    message: `dumpaccess to /${pageName}`,
+    message: `dumpaccess to ${pathname}`,
     level: 'info',
   })
   return (

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,4 +1,5 @@
 import { getPageMeta } from '../../libs/util'
+import { handleForceCacheRefresh } from '../../libs/server/page'
 import NotionSinglePage from '../notion/single-page'
 import { getNotionContent } from '../notion/content'
 import { PAGE_TYPE_NOTION_SINGLE_PAGE } from '../../libs/constant'
@@ -11,6 +12,10 @@ export async function generateMetadata() {
 }
 
 const AboutPage = async ({ searchParams }) => {
+  const pathname = `/${pageName}`
+
+  handleForceCacheRefresh(pathname, searchParams)
+
   const { pageContent } = await getNotionContent({
     pageType: PAGE_TYPE_NOTION_SINGLE_PAGE,
     pageName,
@@ -19,7 +24,7 @@ const AboutPage = async ({ searchParams }) => {
 
   log({
     category: PAGE_TYPE_NOTION_SINGLE_PAGE,
-    message: `dumpaccess to /${pageName}`,
+    message: `dumpaccess to ${pathname}`,
     level: 'info',
   })
   return <NotionSinglePage pageName="about" pageContent={pageContent} />

--- a/src/app/notion/content.ts
+++ b/src/app/notion/content.ts
@@ -1,10 +1,9 @@
 import merge from 'lodash/merge'
 import { ReadonlyURLSearchParams, notFound } from 'next/navigation'
 import { idToUuid } from 'notion-utils'
-import { pageProcessTimeout, cache } from '../../../site.config'
+import { pageProcessTimeout } from '../../../site.config'
 import {
   FAILSAFE_PAGE_GENERATION_QUERY,
-  FORCE_CACHE_REFRESH_QUERY,
   PAGE_TYPE_NOTION_SINGLE_PAGE,
   PAGE_TYPE_NOTION_ARTICLE_LIST_PAGE,
   PAGE_TYPE_NOTION_ARTICLE_DETAIL_PAGE,
@@ -42,7 +41,6 @@ export const getNotionContent = async ({
 
   if (searchParams) {
     timeout = searchParams[FAILSAFE_PAGE_GENERATION_QUERY] === '1' ? 0 : timeout
-    cache.forceRefresh = searchParams[FORCE_CACHE_REFRESH_QUERY] === '1'
   }
 
   const content = await executeFunctionWithTimeout(

--- a/src/libs/server/cache.ts
+++ b/src/libs/server/cache.ts
@@ -47,7 +47,7 @@ class CacheClient {
 
     if (!this.client) {
       log({
-        category: 'cacheClient|proxy',
+        category: 'cacheClient.proxy',
         message: `cache MISS: cacheClient is disabled. | ${message} | key: ${key}`,
       })
       const data = await execFunction()
@@ -58,7 +58,7 @@ class CacheClient {
       const cacheData = await this.client?.get(key)
       if (cacheData && !forceRefresh) {
         log({
-          category: 'cacheClient|proxy',
+          category: 'cacheClient.proxy',
           message: `cache HIT | ${message} | key: ${key}`,
           level: 'debug',
         })
@@ -67,14 +67,14 @@ class CacheClient {
     } catch (err) {
       // swallow redis client errors to prevent app crash
       log({
-        category: 'cacheClient|proxy',
+        category: 'cacheClient.proxy',
         message: err,
         level: 'error',
       })
     }
 
     log({
-      category: 'cacheClient|proxy',
+      category: 'cacheClient.proxy',
       message: `cache MISS${
         forceRefresh ? ' (force refresh)' : ''
       } | ${message} | key: ${key}`,
@@ -88,7 +88,7 @@ class CacheClient {
     } catch (err) {
       // swallow redis client errors to prevent app crash
       log({
-        category: 'cacheClient|proxy',
+        category: 'cacheClient.proxy',
         message: err,
         level: 'error',
       })
@@ -106,7 +106,7 @@ class CacheClient {
   createCacheKeyFromContent(content, prefix = '') {
     if (!content) {
       log({
-        category: 'cacheClient|createCacheKeyFromContent',
+        category: 'cacheClient.createCacheKeyFromContent',
         message: 'content should not be empty',
         level: 'error',
       })


### PR DESCRIPTION
## Goal

<!-- Please describe what's the main purpose of this PR -->

When passing `?fcr=1`, this app will do the below things
1. set a flag to `cache.forceRefresh` to trigger cache client forcely refresh the cached data
2. trigger Vercel Data Cache Revalidation by `revalidatePath`

## Knowledge Transfer / Notes

<!-- Anything worth sharing? E.g. when introducing new technologies, libraries, design patterns, techniques, best practices or any learnings while working on this change. -->

Can not use `revalidatePath` and `revalidateTag` in Edge Middleware.

```
Error: Invariant: static generation store missing in revalidateTag
```

## Reference

<!-- Anything reference can be placed here -->

Vercel Data Cache
- https://vercel.com/docs/infrastructure/data-cache
- https://vercel.com/docs/infrastructure/data-cache/manage-data-cache
- https://nextjs.org/docs/app/api-reference/functions/revalidatePath

Edge Middleware
- https://vercel.com/docs/functions/edge-middleware
- https://vercel.com/docs/functions/edge-middleware/middleware-api